### PR TITLE
perf: remove label colors from github settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -76,17 +76,13 @@ branches:
 # Labels: define labels for Issues and Pull Requests
 labels:
   - name: auro-wcss
-    color: 'fa23e4'
     description:
     process: Key filter for this repo
   - name: duplicate
-    color: '156fad'
     description: This Issue or Pull Request already exists
   - name: not-reviewed
-    color: '222222'
     description: Issue has not been reviewed by Auro team members
   - name: good first issue
-    color: '6bb7fb'
     description: Good for newcomers
     aliases:
     - beginner-friendly
@@ -97,83 +93,65 @@ labels:
     - starter-issue
     - starter
   - name: help wanted
-    color: '6bb7fb'
     description: Extra attention is needed, this user requires assistance to complete
       the work
   - name: released
-    color: 'A9A9A9'
     description: Completed work has been released
   - name: 'Status: Work In Progress'
     description: Issue or Pull Request work is in Progress
-    color: 'c0e585'
   - name: 'Status: Review Needed'
-    color: 'c0e585'
     description: Work is completed, user is requesting feedback
   - name: 'Status: Complete'
-    color: 'c0e585'
     description: Owner has completed work and considers it ready to be merged
   - name: 'Status: Blocked'
-    color: 'df0b37'
     description: Progress on the issue is Blocked, immediate attention is required
     aliases:
     - blocked
   - name: 'Abandoned'
-    color: '156fad'
     description: The author of this issue or Pull Request is not responding
     aliases:
     - wontfix
     - invalid
   - name: 'Type: Bug'
-    color: df0b37
     description: Bug or Bug fixes
     aliases:
     - bug
   - name: 'Type: Feature'
-    color: 'ffd200'
     description: New Feature
     aliases:
     - enhancement
   - name: 'Type: Design'
-    color: 'ffd200'
     description: New or related Design work
     aliases:
     - enhancement
   - name: 'Type: Content'
-    color: 'ffd200'
     description: Adding or editing content
     aliases:
     - enhancement
   - name: 'Type: Refactoring'
-    color: 'ffd200'
     description: A code change that neither fixes a bug nor adds a feature
     aliases:
     - refactor
   - name: 'Type: Documentation'
-    color: 'ffd200'
     description: Documentation only changes
     aliases:
     - documents
     - document
   - name: 'Type: CI'
-    color: 'ffd200'
     description: Changes to CI configuration files and scripts
     aliases:
     - ci
   - name: 'Type: Perf'
-    color: 'ffd200'
     description: Performance update to existing code
   - name: 'Question'
-    color: 'b83302'
     description: Further information is requested
     aliases:
     - question
   - name: 'Type: Dependencies'
-    color: 'ffd200'
     description: Pull requests that update a dependency file
     aliases:
     - dependencies
   - name: 'Type: UI Update'
-    color: 'ffd200'
     description: Changes to the user interface
     aliases:
     - dependencies


### PR DESCRIPTION
## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove label color settings from the GitHub configuration file to streamline label management and reduce unnecessary complexity.

Enhancements:
- Remove color attributes from GitHub label settings to simplify label configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->