### PR TITLE
perf: change import to use for breakpoints

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -16,7 +16,8 @@
         "mixin",
         "return",
         "warn",
-        "extend"
+        "extend",
+        "use"
       ]
     }]
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><title>@aurodesignsystem/webcorestylesheets - v8.0.1</title><link rel="stylesheet" href="assets/css/main.css"><link href="https://fonts.googleapis.com/css?family=Open+Sans:400,500,700" rel="stylesheet" type="text/css"><meta name="viewport" content="width=device-width"><meta content="IE=edge, chrome=1" http-equiv="X-UA-Compatible"><!-- Open Graph tags --><meta property="og:title" content="@aurodesignsystem/webcorestylesheets - SassDoc"><meta property="og:type" content="website"><meta property="og:description" content="<p>Auro core foundation Sass UI Kit</p>
-"><!-- Thanks to Sass-lang.com for the icons --><link href="assets/images/favicon.png" rel="shortcut icon"></head><body><aside class="sidebar" role="nav"><div class="sidebar__header"><h1 class="sidebar__title">@aurodesignsystem/webcorestylesheets - 8.0.1</h1></div><div class="sidebar__body"><button type="button" class="btn-toggle js-btn-toggle" data-alt="Open all">Close all</button><p class="sidebar__item sidebar__item--heading" data-slug="accessibility"><a href="#accessibility">accessibility</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="accessibility-css"><a href="#accessibility-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="accessibility" data-name=":focus" data-type="css"><a href="#accessibility-css-:focus">:focus</a></li><li class="sidebar__item sassdoc__item" data-group="accessibility" data-name="&amp;:focus-visible" data-type="css"><a href="#accessibility-css-&amp;:focus-visible">&amp;:focus-visible</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="animation"><a href="#animation">animation</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="animation-mixin"><a href="#animation-mixin">mixins</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="animation" data-name="auro_transition" data-type="mixin"><a href="#animation-mixin-auro_transition">auro_transition</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="component-support"><a href="#component-support">component-support</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="component-support-css"><a href="#component-support-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="component-support" data-name=":host" data-type="css"><a href="#component-support-css-:host">:host</a></li><li class="sidebar__item sassdoc__item" data-group="component-support" data-name=":host([hidden]:not(:focus):not(:active))" data-type="css"><a href="#component-support-css-:host([hidden]:not(:focus):not(:active))">:host([hidden]:not(:focus):not(:active))</a></li><li class="sidebar__item sassdoc__item" data-group="component-support" data-name=":host([hiddenVisually]:not(:focus):not(:active))" data-type="css"><a href="#component-support-css-:host([hiddenVisually]:not(:focus):not(:active))">:host([hiddenVisually]:not(:focus):not(:active))</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="container"><a href="#container">container</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="container-css"><a href="#container-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="container" data-name="#{$scope}.#{$prefix}container" data-type="css"><a href="#container-css-#{$scope}.#{$prefix}container">#{$scope}.#{$prefix}container</a></li><li class="sidebar__item sassdoc__item" data-group="container" data-name="#{$scope}.#{$prefix}pagecontainer" data-type="css"><a href="#container-css-#{$scope}.#{$prefix}pagecontainer">#{$scope}.#{$prefix}pagecontainer</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="core"><a href="#core">core</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="core-css"><a href="#core-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="core" data-name="#{$sym}#{$prefix}#{$scope}blockquote" data-type="css"><a href="#core-css-#{$sym}#{$prefix}#{$scope}blockquote">#{$sym}#{$prefix}#{$scope}blockquote</a></li><li class="sidebar__item sassdoc__item" data-group="core" data-name="#{$sym}#{$prefix}picture#{$scope}" data-type="css"><a href="#core-css-#{$sym}#{$prefix}picture#{$scope}">#{$sym}#{$prefix}picture#{$scope}</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="essentials"><a href="#essentials">essentials</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="essentials-css"><a href="#essentials-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$sym}#{$prefix}html#{$scope}" data-type="css"><a href="#essentials-css-#{$sym}#{$prefix}html#{$scope}">#{$sym}#{$prefix}html#{$scope}</a></li><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$scope}#{$sym}#{$prefix}body,
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>@aurodesignsystem/webcorestylesheets - v8.1.0</title><link rel="stylesheet" href="assets/css/main.css"><link href="https://fonts.googleapis.com/css?family=Open+Sans:400,500,700" rel="stylesheet" type="text/css"><meta name="viewport" content="width=device-width"><meta content="IE=edge, chrome=1" http-equiv="X-UA-Compatible"><!-- Open Graph tags --><meta property="og:title" content="@aurodesignsystem/webcorestylesheets - SassDoc"><meta property="og:type" content="website"><meta property="og:description" content="<p>Auro core foundation Sass UI Kit</p>
+"><!-- Thanks to Sass-lang.com for the icons --><link href="assets/images/favicon.png" rel="shortcut icon"></head><body><aside class="sidebar" role="nav"><div class="sidebar__header"><h1 class="sidebar__title">@aurodesignsystem/webcorestylesheets - 8.1.0</h1></div><div class="sidebar__body"><button type="button" class="btn-toggle js-btn-toggle" data-alt="Open all">Close all</button><p class="sidebar__item sidebar__item--heading" data-slug="accessibility"><a href="#accessibility">accessibility</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="accessibility-css"><a href="#accessibility-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="accessibility" data-name=":focus" data-type="css"><a href="#accessibility-css-:focus">:focus</a></li><li class="sidebar__item sassdoc__item" data-group="accessibility" data-name="&amp;:focus-visible" data-type="css"><a href="#accessibility-css-&amp;:focus-visible">&amp;:focus-visible</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="animation"><a href="#animation">animation</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="animation-mixin"><a href="#animation-mixin">mixins</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="animation" data-name="auro_transition" data-type="mixin"><a href="#animation-mixin-auro_transition">auro_transition</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="component-support"><a href="#component-support">component-support</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="component-support-css"><a href="#component-support-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="component-support" data-name=":host" data-type="css"><a href="#component-support-css-:host">:host</a></li><li class="sidebar__item sassdoc__item" data-group="component-support" data-name=":host([hidden]:not(:focus):not(:active))" data-type="css"><a href="#component-support-css-:host([hidden]:not(:focus):not(:active))">:host([hidden]:not(:focus):not(:active))</a></li><li class="sidebar__item sassdoc__item" data-group="component-support" data-name=":host([hiddenVisually]:not(:focus):not(:active))" data-type="css"><a href="#component-support-css-:host([hiddenVisually]:not(:focus):not(:active))">:host([hiddenVisually]:not(:focus):not(:active))</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="container"><a href="#container">container</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="container-css"><a href="#container-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="container" data-name="#{$scope}.#{$prefix}container" data-type="css"><a href="#container-css-#{$scope}.#{$prefix}container">#{$scope}.#{$prefix}container</a></li><li class="sidebar__item sassdoc__item" data-group="container" data-name="#{$scope}.#{$prefix}pagecontainer" data-type="css"><a href="#container-css-#{$scope}.#{$prefix}pagecontainer">#{$scope}.#{$prefix}pagecontainer</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="core"><a href="#core">core</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="core-css"><a href="#core-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="core" data-name="#{$sym}#{$prefix}#{$scope}blockquote" data-type="css"><a href="#core-css-#{$sym}#{$prefix}#{$scope}blockquote">#{$sym}#{$prefix}#{$scope}blockquote</a></li><li class="sidebar__item sassdoc__item" data-group="core" data-name="#{$sym}#{$prefix}picture#{$scope}" data-type="css"><a href="#core-css-#{$sym}#{$prefix}picture#{$scope}">#{$sym}#{$prefix}picture#{$scope}</a></li></ul></div><p class="sidebar__item sidebar__item--heading" data-slug="essentials"><a href="#essentials">essentials</a></p><div><p class="sidebar__item sidebar__item--sub-heading" data-slug="essentials-css"><a href="#essentials-css">css</a></p><ul class="list-unstyled"><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$sym}#{$prefix}html#{$scope}" data-type="css"><a href="#essentials-css-#{$sym}#{$prefix}html#{$scope}">#{$sym}#{$prefix}html#{$scope}</a></li><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$scope}#{$sym}#{$prefix}body,
 #{$scope}.#{$prefix}baseType" data-type="css"><a href="#essentials-css-#{$scope}#{$sym}#{$prefix}body,
 #{$scope}.#{$prefix}baseType">#{$scope}#{$sym}#{$prefix}body, #{$scope}.#{$prefix}baseType</a></li><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$scope}.#{$prefix}baseParagraph" data-type="css"><a href="#essentials-css-#{$scope}.#{$prefix}baseParagraph">#{$scope}.#{$prefix}baseParagraph</a></li><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$scope}.#{$prefix}hyperlink" data-type="css"><a href="#essentials-css-#{$scope}.#{$prefix}hyperlink">#{$scope}.#{$prefix}hyperlink</a></li><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$scope}#{$sym}#{$prefix}img" data-type="css"><a href="#essentials-css-#{$scope}#{$sym}#{$prefix}img">#{$scope}#{$sym}#{$prefix}img</a></li><li class="sidebar__item sassdoc__item" data-group="essentials" data-name="#{$scope}#{$sym}#{$prefix}small,
 #{$scope}.#{$prefix}type--small" data-type="css"><a href="#essentials-css-#{$scope}#{$sym}#{$prefix}small,
@@ -53,23 +53,23 @@
 }</code>" data-collapsed=":host([hiddenVisually]:not(:focus):not(:active)) { ... }"><code>:host([hiddenVisually]:not(:focus):not(:active)) { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Component a11y support for <code>:host</code> selector with <code>hiddenVisually</code> attribute<br>For use with auroElement.js base class and web component development</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector</p></div><pre class="example__code language-scss"><code>:host([hiddenVisually]:not(:focus):not(:active)) {}</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/auroElement/auroElement&quot;;</code></pre></div></section></section></section><section class="main__section"><h1 class="main__heading" id="container"><div class="container">container</div></h1><section class="main__sub-section" id="container-css"><h2 class="main__heading--secondary"><div class="container">css</div></h2><section class="main__item container item" id="container-css-#{$scope}.#{$prefix}container"><h3 class="item__heading"><a class="item__name" href="#css-#{$scope}.#{$prefix}container">#{$scope}.#{$prefix}container</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="<code>#{$scope}.#{$prefix}container {
   display: grid;
   @include grid_margin();
-  @include grid_width($ds-grid-breakpoint-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
 }</code>" data-collapsed="#{$scope}.#{$prefix}container { ... }"><code>#{$scope}.#{$prefix}container { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Container class</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> and <code>$prefix</code> options.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>.container {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro .container {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $prefix: true;</p></div><pre class="example__code language-scss"><code>.auro_container {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Example HTML selector use</p></div><pre class="example__code language-html"><code>&lt;element class=&quot;container&quot;&gt; ... &lt;/element&gt;</code></pre></div><div class="item__example example"><div class="example__description"><p>import file;</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="container-css-#{$scope}.#{$prefix}pagecontainer"><h3 class="item__heading"><a class="item__name" href="#css-#{$scope}.#{$prefix}pagecontainer">#{$scope}.#{$prefix}pagecontainer</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="<code>#{$scope}.#{$prefix}pagecontainer {
-  @include grid_padding($ds-grid-margin-xs);
+  @include grid_padding(vac.$ds-grid-margin-xs);
   @include grid_margin();
-  @include grid_width($ds-grid-breakpoint-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
 
   @include auro_grid-breakpoint--sm {
-    @include grid_padding($ds-grid-margin-sm);
+    @include grid_padding(vac.$ds-grid-margin-sm);
   }
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
   }
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
   &amp;.breadcrumbs {
@@ -210,11 +210,11 @@
   line-height: var(--ds-text-body-height-xs, $ds-text-body-height-xs);
   color: var(--ds-color-text-secondary-default, $ds-color-text-secondary-default);
 }</code>" data-collapsed="#{$scope}.#{$prefix}fineprint { ... }"><code>#{$scope}.#{$prefix}fineprint { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Defines the font size and color of fine print text</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> and <code>$prefix</code> options.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>.fineprint {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro .fineprint {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $prefix: true;</p></div><pre class="example__code language-scss"><code>.auro_fineprint {}</code></pre></div><div class="item__example example"><div class="example__description"><p>import file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/essentials&quot;;</code></pre></div></section></section></section><section class="main__section"><h1 class="main__heading" id="grid"><div class="container">grid</div></h1><section class="main__sub-section" id="grid-mixin"><h2 class="main__heading--secondary"><div class="container">mixins</div></h2><section class="main__item container item" id="grid-mixin-grid-stickycolumn--md"><h3 class="item__heading"><a class="item__name" href="#mixin-grid-stickycolumn--md">grid-stickycolumn--md</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin grid-stickycolumn--md() { 
-  @media screen and (min-width: $ds-grid-breakpoint-md) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-md) {
     position: sticky;
     top: 0;
     max-height: 100vh;
-    padding-top: var(--ds-grid-margin-xl, $ds-grid-margin-xl);
+    padding-top: var(--ds-grid-margin-xl, vac.$ds-grid-margin-xl);
     @content;
   }
  }" data-collapsed="@mixin grid-stickycolumn--md() { ... }"><code>@mixin grid-stickycolumn--md() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>This mixin will set the element to be sticky on tablet and larger devices.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="grid-mixin-grid-stickycolumn--xs"><h3 class="item__heading"><a class="item__name" href="#mixin-grid-stickycolumn--xs">grid-stickycolumn--xs</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin grid-stickycolumn--xs() { 
@@ -224,29 +224,29 @@
   align-self: var(--align-self);
  }" data-collapsed="@mixin grid-stickycolumn--xs() { ... }"><code>@mixin grid-stickycolumn--xs() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>This mixin will set the element to be sticky on mobile devices.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="grid-mixin-grid_width"><h3 class="item__heading"><a class="item__name" href="#mixin-grid_width">grid_width</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin grid_width($maxWidth: 1232px) { 
   max-width: $maxWidth;
- }" data-collapsed="@mixin grid_width($maxWidth: 1232px) { ... }"><code>@mixin grid_width($maxWidth: 1232px) { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><table class="item__parameters"><thead><tr><th scope="col"><span class="visually-hidden">parameter </span>Name</th><th scope="col"><span class="visually-hidden">parameter </span>Description</th><th scope="col"><span class="visually-hidden">parameter </span>Type</th><th scope="col"><span class="visually-hidden">parameter </span>Default value</th></tr></thead><tbody><tr class="item__parameter"><th scope="row" data-label="name"><code>$maxWidth</code></th><td data-label="desc"><p>Specifies the max-width value of the grid.</p></td><td data-label="type"><code>String</code></td><td data-label="default"><code>1232px</code></td></tr></tbody></table><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>$maxWidth: $ds-grid-breakpoint-xl !default;
+ }" data-collapsed="@mixin grid_width($maxWidth: 1232px) { ... }"><code>@mixin grid_width($maxWidth: 1232px) { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><table class="item__parameters"><thead><tr><th scope="col"><span class="visually-hidden">parameter </span>Name</th><th scope="col"><span class="visually-hidden">parameter </span>Description</th><th scope="col"><span class="visually-hidden">parameter </span>Type</th><th scope="col"><span class="visually-hidden">parameter </span>Default value</th></tr></thead><tbody><tr class="item__parameter"><th scope="row" data-label="name"><code>$maxWidth</code></th><td data-label="desc"><p>Specifies the max-width value of the grid.</p></td><td data-label="type"><code>String</code></td><td data-label="default"><code>1232px</code></td></tr></tbody></table><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>$maxWidth: vac.$ds-grid-breakpoint-xl !default;
 @import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="grid-mixin-grid_margin"><h3 class="item__heading"><a class="item__name" href="#mixin-grid_margin">grid_margin</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin grid_margin() { 
   margin-left: auto;
   margin-right: auto;
  }" data-collapsed="@mixin grid_margin() { ... }"><code>@mixin grid_margin() { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="grid-mixin-grid_padding"><h3 class="item__heading"><a class="item__name" href="#mixin-grid_padding">grid_padding</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin grid_padding() { 
   padding-left: $padding;
   padding-right: $padding;
- }" data-collapsed="@mixin grid_padding() { ... }"><code>@mixin grid_padding() { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>$padding: $ds-grid-margin-xs !default;
+ }" data-collapsed="@mixin grid_padding() { ... }"><code>@mixin grid_padding() { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>$padding: vac.$ds-grid-margin-xs !default;
   @import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="grid-mixin-grid_gutter"><h3 class="item__heading"><a class="item__name" href="#mixin-grid_gutter">grid_gutter</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin grid_gutter($gutter: 16px) { 
   gap: $gutter;
   @include auro_grid-breakpoint--sm {
-   gap: var(--ds-grid-gutter-sm, $ds-grid-gutter-sm);
+   gap: var(--ds-grid-gutter-sm, vac.$ds-grid-gutter-sm);
   }
   @include auro_grid-breakpoint--md {
-    gap: var(--ds-grid-gutter-md, $ds-grid-gutter-md);
+    gap: var(--ds-grid-gutter-md, vac.$ds-grid-gutter-md);
   }
   @include auro_grid-breakpoint--lg {
-    gap: var(--ds-grid-gutter-lg, $ds-grid-gutter-lg);
+    gap: var(--ds-grid-gutter-lg, vac.$ds-grid-gutter-lg);
   }
   @include auro_grid-breakpoint--xl {
-    gap: var(--ds-grid-gutter-xl, $ds-grid-gutter-xl);
+    gap: var(--ds-grid-gutter-xl, vac.$ds-grid-gutter-xl);
   }
- }" data-collapsed="@mixin grid_gutter($gutter: 16px) { ... }"><code>@mixin grid_gutter($gutter: 16px) { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><table class="item__parameters"><thead><tr><th scope="col"><span class="visually-hidden">parameter </span>Name</th><th scope="col"><span class="visually-hidden">parameter </span>Description</th><th scope="col"><span class="visually-hidden">parameter </span>Type</th><th scope="col"><span class="visually-hidden">parameter </span>Default value</th></tr></thead><tbody><tr class="item__parameter"><th scope="row" data-label="name"><code>$gutter</code></th><td data-label="desc"><p>Specifies the gutter/gap(horizontal &amp; vertical spacing) value between each cell of the grid.</p></td><td data-label="type"><code>String</code></td><td data-label="default"><code>16px</code></td></tr></tbody></table><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>$gutter: $ds-grid-gutter-xs !default;
+ }" data-collapsed="@mixin grid_gutter($gutter: 16px) { ... }"><code>@mixin grid_gutter($gutter: 16px) { ... }</code></pre></div><h3 class="item__sub-heading">Parameters</h3><table class="item__parameters"><thead><tr><th scope="col"><span class="visually-hidden">parameter </span>Name</th><th scope="col"><span class="visually-hidden">parameter </span>Description</th><th scope="col"><span class="visually-hidden">parameter </span>Type</th><th scope="col"><span class="visually-hidden">parameter </span>Default value</th></tr></thead><tbody><tr class="item__parameter"><th scope="row" data-label="name"><code>$gutter</code></th><td data-label="desc"><p>Specifies the gutter/gap(horizontal &amp; vertical spacing) value between each cell of the grid.</p></td><td data-label="type"><code>String</code></td><td data-label="default"><code>16px</code></td></tr></tbody></table><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file with altered output values prior to import</p></div><pre class="example__code language-scss"><code>$gutter: vac.$ds-grid-gutter-xs !default;
 @import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section></section></section><section class="main__section"><h1 class="main__heading" id="headings"><div class="container">headings</div></h1><section class="main__sub-section" id="headings-css"><h2 class="main__heading--secondary"><div class="container">css</div></h2><section class="main__item container item" id="headings-css-#{$scope}.#{$prefix}heading"><h3 class="item__heading"><a class="item__name" href="#css-#{$scope}.#{$prefix}heading">#{$scope}.#{$prefix}heading</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="<code>#{$scope}.#{$prefix}heading {
   margin: calc(#{$ds-size-200} + #{$ds-size-150}) 0;
 
@@ -552,29 +552,29 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
 }</code>" data-collapsed="#{$scope}[hidden] { ... }"><code>#{$scope}[hidden] { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Add the correct display in IE 10.</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> option.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>[hidden] {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro [hidden] {}</code></pre></div><div class="item__example example"><div class="example__description"><p>import file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/normalize&quot;;</code></pre></div></section></section></section><section class="main__section"><h1 class="main__heading" id="page layouts"><div class="container">page layouts</div></h1><section class="main__sub-section" id="page layouts-css"><h2 class="main__heading--secondary"><div class="container">css</div></h2><section class="main__item container item" id="page layouts-css-#{$scope}.#{$prefix}pageLayout-2colAnchorNav"><h3 class="item__heading"><a class="item__name" href="#css-#{$scope}.#{$prefix}pageLayout-2colAnchorNav">#{$scope}.#{$prefix}pageLayout-2colAnchorNav</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="<code>#{$scope}.#{$prefix}pageLayout-2colAnchorNav {
   display: grid;
   @include grid_margin();
-  @include grid_padding($ds-grid-margin-xs);
-  @include grid_width($ds-grid-breakpoint-xl);
-  @include grid_gutter($ds-grid-gutter-xl);
+  @include grid_padding(vac.$ds-grid-margin-xs);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
+  @include grid_gutter(vac.$ds-grid-gutter-xl);
   grid-template-areas:
   &quot;breadcrumbs&quot;
   &quot;anchornav&quot;
   &quot;main&quot;;
 
   @include auro_grid-breakpoint--sm {
-    @include grid_padding($ds-grid-margin-sm);
+    @include grid_padding(vac.$ds-grid-margin-sm);
   }
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
     grid-template-columns: auto var(--fixed-anchor-width, $fixed-anchor-width);
       grid-template-areas:
       &quot;breadcrumbs breadcrumbs&quot;
       &quot;main anchornav&quot;;
   }
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
   .breadcrumbs {
@@ -583,7 +583,7 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
   .main {
     grid-area: main;
     * {
-      scroll-margin-top: var(--ds-grid-margin-md, $ds-grid-margin-md);
+      scroll-margin-top: var(--ds-grid-margin-md, vac.$ds-grid-margin-md);
     }
   }
   .anchornav {
@@ -594,8 +594,8 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
   display: grid;
   @include grid_margin();
   @include grid_padding(0);
-  @include grid_width($ds-grid-breakpoint-xl);
-  @include grid_gutter($ds-grid-gutter-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
+  @include grid_gutter(vac.$ds-grid-gutter-xl);
   grid-template-areas:
   &quot;breadcrumbs&quot;
   &quot;sidenav&quot;
@@ -603,7 +603,7 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
 
 
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
     grid-template-columns: var(--fixed-nav-width, $fixed-nav-width) auto;
       grid-template-areas:
       &quot;breadcrumbs breadcrumbs&quot;
@@ -611,16 +611,16 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
   }
 
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
 
   .breadcrumbs {
     grid-area: breadcrumbs;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
     }
@@ -629,7 +629,7 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
   .sidenav {
     grid-area: sidenav;
     background-color: var(--ds-color-container-primary-default, $ds-color-container-primary-default);
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
 
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
@@ -639,20 +639,20 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
 
   .main {
     grid-area: main;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
     @include grid_padding(0);
     }
     * {
-      scroll-margin-top: var(--ds-grid-margin-md, $ds-grid-margin-md);
+      scroll-margin-top: var(--ds-grid-margin-md, vac.$ds-grid-margin-md);
     }
   }
 }</code>" data-collapsed="#{$scope}.#{$prefix}pageLayout-2colSideNav { ... }"><code>#{$scope}.#{$prefix}pageLayout-2colSideNav { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>pageLayout-2colSideNav class</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> and <code>$prefix</code> options.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>.pageLayout-2colSideNav {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro .pageLayout-2colSideNav {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $prefix: true;</p></div><pre class="example__code language-scss"><code>.auro_pageLayout-2colSideNav {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Example HTML selector use</p></div><pre class="example__code language-html"><code>&lt;element class=&quot;pageLayout-2colSideNav&quot;&gt; ... &lt;/element&gt;</code></pre></div><div class="item__example example"><div class="example__description"><p>import file;</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids&quot;;</code></pre></div></section><section class="main__item container item" id="page layouts-css-#{$scope}.#{$prefix}pageLayout-3col"><h3 class="item__heading"><a class="item__name" href="#css-#{$scope}.#{$prefix}pageLayout-3col">#{$scope}.#{$prefix}pageLayout-3col</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="<code>#{$scope}.#{$prefix}pageLayout-3col {
   display: grid;
   @include grid_margin();
   @include grid_padding(0);
-  @include grid_width($ds-grid-breakpoint-xl);
-  @include grid_gutter($ds-grid-gutter-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
+  @include grid_gutter(vac.$ds-grid-gutter-xl);
   grid-template-areas:
   &quot;breadcrumbs&quot;
   &quot;sidenav&quot;
@@ -661,7 +661,7 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
 
 
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
     grid-template-columns: var(--fixed-nav-width, $fixed-nav-width) auto var(--fixed-anchor-width, $fixed-anchor-width);
       grid-template-areas:
       &quot;breadcrumbs breadcrumbs breadcrumbs&quot;
@@ -669,16 +669,16 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
   }
 
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
 
   .breadcrumbs {
     grid-area: breadcrumbs;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
     }
@@ -688,7 +688,7 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
     grid-area: sidenav;
     z-index: 1;
     background-color: var(--ds-color-container-primary-default, $ds-color-container-primary-default);
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include grid-stickycolumn--xs();
 
 
@@ -700,19 +700,19 @@ select {}</code></pre></div><div class="item__example example"><div class="examp
 
   .main {
     grid-area: main;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
     @include grid_padding(0);
     }
     * {
-      scroll-margin-top: var(--ds-grid-margin-md, $ds-grid-margin-md);
+      scroll-margin-top: var(--ds-grid-margin-md, vac.$ds-grid-margin-md);
     }
   }
 
   .anchornav {
     grid-area: anchornav;
     @include grid-stickycolumn--md;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
 
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
@@ -761,7 +761,7 @@ $ds-grid-breakpoint-lg: 1024px;</code></pre></div><div class="item__example exam
     color: blue;
   }
 }</code></pre></div></section><section class="main__item container item" id="responsive-mixin-auro_grid-breakpoint--xl"><h3 class="item__heading"><a class="item__name" href="#mixin-auro_grid-breakpoint--xl">auro_grid-breakpoint--xl</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin auro_grid-breakpoint--xl() { 
-  @media screen and (min-width: $ds-grid-breakpoint-xl) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-xl) {
     @content;
   }
  }" data-collapsed="@mixin auro_grid-breakpoint--xl() { ... }"><code>@mixin auro_grid-breakpoint--xl() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Standard breakpoint to support resolutions greater than 1232px.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grid-breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>Set grid-breakpoint</p></div><pre class="example__code language-scss"><code>.foo {
@@ -769,7 +769,7 @@ $ds-grid-breakpoint-lg: 1024px;</code></pre></div><div class="item__example exam
       ...
     }
 }</code></pre></div></section><section class="main__item container item" id="responsive-mixin-auro_grid-breakpoint--lg"><h3 class="item__heading"><a class="item__name" href="#mixin-auro_grid-breakpoint--lg">auro_grid-breakpoint--lg</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin auro_grid-breakpoint--lg() { 
-  @media screen and (min-width: $ds-grid-breakpoint-lg) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-lg) {
     @content;
   }
  }" data-collapsed="@mixin auro_grid-breakpoint--lg() { ... }"><code>@mixin auro_grid-breakpoint--lg() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Standard breakpoint to support resolutions greater than 1024px.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grid-breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>Set grid-breakpoint</p></div><pre class="example__code language-scss"><code>.foo {
@@ -777,7 +777,7 @@ $ds-grid-breakpoint-lg: 1024px;</code></pre></div><div class="item__example exam
       ...
     }
 }</code></pre></div></section><section class="main__item container item" id="responsive-mixin-auro_grid-breakpoint--md"><h3 class="item__heading"><a class="item__name" href="#mixin-auro_grid-breakpoint--md">auro_grid-breakpoint--md</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin auro_grid-breakpoint--md() { 
-  @media screen and (min-width: $ds-grid-breakpoint-md) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-md) {
     @content;
   }
  }" data-collapsed="@mixin auro_grid-breakpoint--md() { ... }"><code>@mixin auro_grid-breakpoint--md() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Standard breakpoint to support resolutions greater than 768px.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grid-breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>Set grid-breakpoint</p></div><pre class="example__code language-scss"><code>.foo {
@@ -785,7 +785,7 @@ $ds-grid-breakpoint-lg: 1024px;</code></pre></div><div class="item__example exam
       ...
     }
 }</code></pre></div></section><section class="main__item container item" id="responsive-mixin-auro_grid-breakpoint--sm"><h3 class="item__heading"><a class="item__name" href="#mixin-auro_grid-breakpoint--sm">auro_grid-breakpoint--sm</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin auro_grid-breakpoint--sm() { 
-  @media screen and (min-width: $ds-grid-breakpoint-sm) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-sm) {
     @content;
   }
  }" data-collapsed="@mixin auro_grid-breakpoint--sm() { ... }"><code>@mixin auro_grid-breakpoint--sm() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Standard breakpoint to support resolutions greater than 576px.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grid-breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>Set grid-breakpoint</p></div><pre class="example__code language-scss"><code>.foo {
@@ -793,7 +793,7 @@ $ds-grid-breakpoint-lg: 1024px;</code></pre></div><div class="item__example exam
       ...
     }
 }</code></pre></div></section><section class="main__item container item" id="responsive-mixin-auro_grid-breakpoint--xs"><h3 class="item__heading"><a class="item__name" href="#mixin-auro_grid-breakpoint--xs">auro_grid-breakpoint--xs</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="@mixin auro_grid-breakpoint--xs() { 
-  @media screen and (min-width: $ds-grid-breakpoint-xs) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-xs) {
     @content;
   }
  }" data-collapsed="@mixin auro_grid-breakpoint--xs() { ... }"><code>@mixin auro_grid-breakpoint--xs() { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Standard breakpoint to support resolutions greater than 320px.</p></div><h3 class="item__sub-heading">Parameters</h3><p>None.</p><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/grid-breakpoints&quot;;</code></pre></div><div class="item__example example"><div class="example__description"><p>Set grid-breakpoint</p></div><pre class="example__code language-scss"><code>.foo {
@@ -1564,4 +1564,4 @@ $ds-spacing-options: 200;
   white-space: nowrap $important;
 }</code>" data-collapsed="#{$scope}.#{$prefix}util_nowrap { ... }"><code>#{$scope}.#{$prefix}util_nowrap { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Utility class force no wrap on content</p><p><a href="/#utility-variable-important">Manage</a> <code>!important</code> flag.</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> and <code>$prefix</code> options.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>.util_nowrap {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro .util_nowrap {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $prefix: true;</p></div><pre class="example__code language-scss"><code>.auro_util_nowrap {}</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/utilityClasses/typeProperties&quot;;</code></pre></div></section><section class="main__item container item" id="utility-type-css-#{$scope}.#{$prefix}util_capitalize"><h3 class="item__heading"><a class="item__name" href="#css-#{$scope}.#{$prefix}util_capitalize">#{$scope}.#{$prefix}util_capitalize</a></h3><div class="item__code-wrapper"><pre class="item__code item__code--togglable language-scss" data-current-state="collapsed" data-expanded="<code>#{$scope}.#{$prefix}util_capitalize {
   text-transform: capitalize $important;
-}</code>" data-collapsed="#{$scope}.#{$prefix}util_capitalize { ... }"><code>#{$scope}.#{$prefix}util_capitalize { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Utility class to capitalize a string</p><p><a href="/#utility-variable-important">Manage</a> <code>!important</code> flag.</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> and <code>$prefix</code> options.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>.util_capitalize {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro .util_capitalize {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $prefix: true;</p></div><pre class="example__code language-scss"><code>.auro_util_capitalize {}</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/utilityClasses/typeProperties&quot;;</code></pre></div></section></section></section><footer class="footer" role="contentinfo"><div class="container"><div class="footer__project-info project-info"><!-- Name and URL --> <span class="project-info__name">@aurodesignsystem/webcorestylesheets</span><!-- Version --> <span class="project-info__version">- v8.0.1</span><!-- License --> <span class="project-info__license">, under Apache-2.0</span></div><a class="footer__watermark" href="http://sassdoc.com"><img src="assets/images/logo_light_inline.svg" alt="SassDoc Logo"></a></div></footer></article><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script><script>window.jQuery || document.write('<script src="assets/js/vendor/jquery.min.js"><\/script>')</script><script src="assets/js/main.min.js"></script></body></html>
+}</code>" data-collapsed="#{$scope}.#{$prefix}util_capitalize { ... }"><code>#{$scope}.#{$prefix}util_capitalize { ... }</code></pre></div><h3 class="item__sub-heading">Description</h3><div class="item__description"><p>Utility class to capitalize a string</p><p><a href="/#utility-variable-important">Manage</a> <code>!important</code> flag.</p><p><a href="/#scope-prefix-variable-scope">Manage</a> <code>$scope</code> and <code>$prefix</code> options.</p></div><h3 class="item__sub-heading">Example</h3><div class="item__example example"><div class="example__description"><p>Default selector(s)</p></div><pre class="example__code language-scss"><code>.util_capitalize {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $scope: true;</p></div><pre class="example__code language-scss"><code>.auro .util_capitalize {}</code></pre></div><div class="item__example example"><div class="example__description"><p>Selector(s) when $prefix: true;</p></div><pre class="example__code language-scss"><code>.auro_util_capitalize {}</code></pre></div><div class="item__example example"><div class="example__description"><p>import mixin file</p></div><pre class="example__code language-scss"><code>@import &quot;./node_modules/@aurodesignsystem/webcorestylesheets/dist/utilityClasses/typeProperties&quot;;</code></pre></div></section></section></section><footer class="footer" role="contentinfo"><div class="container"><div class="footer__project-info project-info"><!-- Name and URL --> <span class="project-info__name">@aurodesignsystem/webcorestylesheets</span><!-- Version --> <span class="project-info__version">- v8.1.0</span><!-- License --> <span class="project-info__license">, under Apache-2.0</span></div><a class="footer__watermark" href="http://sassdoc.com"><img src="assets/images/logo_light_inline.svg" alt="SassDoc Logo"></a></div></footer></article><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script><script>window.jQuery || document.write('<script src="assets/js/vendor/jquery.min.js"><\/script>')</script><script src="assets/js/main.min.js"></script></body></html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/webcorestylesheets",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/webcorestylesheets",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/_breakpoints.scss
+++ b/src/_breakpoints.scss
@@ -3,6 +3,12 @@
 
 // ---------------------------------------------------------------------
 
+/* stylelint-disable no-invalid-position-at-import-rule */
+
+// @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
+
+@use '../node_modules/@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables' as vac;
+
 @import './libSupport/deprecated';
 
 // The following mixins provide pre-configured Orion approved
@@ -85,7 +91,7 @@
 ///       }
 ///   }
 @mixin auro_grid-breakpoint--xl {
-  @media screen and (min-width: $ds-grid-breakpoint-xl) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-xl) {
     @content;
   }
 }
@@ -101,7 +107,7 @@
 ///       }
 ///   }
 @mixin auro_grid-breakpoint--lg {
-  @media screen and (min-width: $ds-grid-breakpoint-lg) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-lg) {
     @content;
   }
 }
@@ -117,7 +123,7 @@
 ///       }
 ///   }
 @mixin auro_grid-breakpoint--md {
-  @media screen and (min-width: $ds-grid-breakpoint-md) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-md) {
     @content;
   }
 }
@@ -133,7 +139,7 @@
 ///       }
 ///   }
 @mixin auro_grid-breakpoint--sm {
-  @media screen and (min-width: $ds-grid-breakpoint-sm) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-sm) {
     @content;
   }
 }
@@ -149,7 +155,7 @@
 ///       }
 ///   }
 @mixin auro_grid-breakpoint--xs {
-  @media screen and (min-width: $ds-grid-breakpoint-xs) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-xs) {
     @content;
   }
 }

--- a/src/_grids.scss
+++ b/src/_grids.scss
@@ -3,7 +3,8 @@
 
 // ---------------------------------------------------------------------
 
-// sass-lint:disable mixins-before-declarations variable-for-property no-vendor-prefixes
+// stylelint-disable mixins-before-declarations, variable-for-property, no-vendor-prefixes, no-invalid-position-at-import-rule
+@use '../node_modules/@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables' as vac;
 @import 'libSupport/manageScope';
 
 $fixed-nav-width: 280px;
@@ -19,11 +20,11 @@ $fixed-anchor-width: 168px;
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 ///
 @mixin grid-stickycolumn--md {
-  @media screen and (min-width: $ds-grid-breakpoint-md) {
+  @media screen and (min-width: vac.$ds-grid-breakpoint-md) {
     position: sticky;
     top: 0;
     max-height: 100vh;
-    padding-top: var(--ds-grid-margin-xl, $ds-grid-margin-xl);
+    padding-top: var(--ds-grid-margin-xl, vac.$ds-grid-margin-xl);
     @content;
   }
 }
@@ -49,7 +50,7 @@ $fixed-anchor-width: 168px;
 /// @example scss - import mixin file
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 /// @example scss - import mixin file with altered output values prior to import
-///   $maxWidth: $ds-grid-breakpoint-xl !default;
+///   $maxWidth: vac.$ds-grid-breakpoint-xl !default;
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 ///
 @mixin grid_width($maxWidth) {
@@ -70,7 +71,7 @@ $fixed-anchor-width: 168px;
 /// @example scss - import mixin file
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 /// @example scss - import mixin file with altered output values prior to import
-/// $padding: $ds-grid-margin-xs !default;
+/// $padding: vac.$ds-grid-margin-xs !default;
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 @mixin grid_padding($padding) {
   padding-left: $padding;
@@ -82,21 +83,21 @@ $fixed-anchor-width: 168px;
 /// @example scss - import mixin file
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/breakpoints";
 /// @example scss - import mixin file with altered output values prior to import
-///   $gutter: $ds-grid-gutter-xs !default;
+///   $gutter: vac.$ds-grid-gutter-xs !default;
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 @mixin grid_gutter($gutter) {
   gap: $gutter;
   @include auro_grid-breakpoint--sm {
-   gap: var(--ds-grid-gutter-sm, $ds-grid-gutter-sm);
+   gap: var(--ds-grid-gutter-sm, vac.$ds-grid-gutter-sm);
   }
   @include auro_grid-breakpoint--md {
-    gap: var(--ds-grid-gutter-md, $ds-grid-gutter-md);
+    gap: var(--ds-grid-gutter-md, vac.$ds-grid-gutter-md);
   }
   @include auro_grid-breakpoint--lg {
-    gap: var(--ds-grid-gutter-lg, $ds-grid-gutter-lg);
+    gap: var(--ds-grid-gutter-lg, vac.$ds-grid-gutter-lg);
   }
   @include auro_grid-breakpoint--xl {
-    gap: var(--ds-grid-gutter-xl, $ds-grid-gutter-xl);
+    gap: var(--ds-grid-gutter-xl, vac.$ds-grid-gutter-xl);
   }
 }
 
@@ -121,7 +122,7 @@ $fixed-anchor-width: 168px;
 #{$scope}.#{$prefix}container {
   display: grid;
   @include grid_margin();
-  @include grid_width($ds-grid-breakpoint-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
 }
 
 /// Container class
@@ -143,21 +144,21 @@ $fixed-anchor-width: 168px;
 ///   @import "./node_modules/@aurodesignsystem/webcorestylesheets/dist/grids";
 ///
 #{$scope}.#{$prefix}pagecontainer {
-  @include grid_padding($ds-grid-margin-xs);
+  @include grid_padding(vac.$ds-grid-margin-xs);
   @include grid_margin();
-  @include grid_width($ds-grid-breakpoint-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
 
   @include auro_grid-breakpoint--sm {
-    @include grid_padding($ds-grid-margin-sm);
+    @include grid_padding(vac.$ds-grid-margin-sm);
   }
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
   }
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
   &.breadcrumbs {
@@ -186,29 +187,29 @@ $fixed-anchor-width: 168px;
 #{$scope}.#{$prefix}pageLayout-2colAnchorNav {
   display: grid;
   @include grid_margin();
-  @include grid_padding($ds-grid-margin-xs);
-  @include grid_width($ds-grid-breakpoint-xl);
-  @include grid_gutter($ds-grid-gutter-xl);
+  @include grid_padding(vac.$ds-grid-margin-xs);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
+  @include grid_gutter(vac.$ds-grid-gutter-xl);
   grid-template-areas:
   "breadcrumbs"
   "anchornav"
   "main";
 
   @include auro_grid-breakpoint--sm {
-    @include grid_padding($ds-grid-margin-sm);
+    @include grid_padding(vac.$ds-grid-margin-sm);
   }
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
     grid-template-columns: auto var(--fixed-anchor-width, $fixed-anchor-width);
       grid-template-areas:
       "breadcrumbs breadcrumbs"
       "main anchornav";
   }
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
   .breadcrumbs {
@@ -217,7 +218,7 @@ $fixed-anchor-width: 168px;
   .main {
     grid-area: main;
     * {
-      scroll-margin-top: var(--ds-grid-margin-md, $ds-grid-margin-md);
+      scroll-margin-top: var(--ds-grid-margin-md, vac.$ds-grid-margin-md);
     }
   }
   .anchornav {
@@ -248,8 +249,8 @@ $fixed-anchor-width: 168px;
   display: grid;
   @include grid_margin();
   @include grid_padding(0);
-  @include grid_width($ds-grid-breakpoint-xl);
-  @include grid_gutter($ds-grid-gutter-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
+  @include grid_gutter(vac.$ds-grid-gutter-xl);
   grid-template-areas:
   "breadcrumbs"
   "sidenav"
@@ -257,7 +258,7 @@ $fixed-anchor-width: 168px;
 
 
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
     grid-template-columns: var(--fixed-nav-width, $fixed-nav-width) auto;
       grid-template-areas:
       "breadcrumbs breadcrumbs"
@@ -265,16 +266,16 @@ $fixed-anchor-width: 168px;
   }
 
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
 
   .breadcrumbs {
     grid-area: breadcrumbs;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
     }
@@ -283,7 +284,7 @@ $fixed-anchor-width: 168px;
   .sidenav {
     grid-area: sidenav;
     background-color: var(--ds-color-container-primary-default, $ds-color-container-primary-default);
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
 
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
@@ -293,12 +294,12 @@ $fixed-anchor-width: 168px;
 
   .main {
     grid-area: main;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
     @include grid_padding(0);
     }
     * {
-      scroll-margin-top: var(--ds-grid-margin-md, $ds-grid-margin-md);
+      scroll-margin-top: var(--ds-grid-margin-md, vac.$ds-grid-margin-md);
     }
   }
 }
@@ -325,8 +326,8 @@ $fixed-anchor-width: 168px;
   display: grid;
   @include grid_margin();
   @include grid_padding(0);
-  @include grid_width($ds-grid-breakpoint-xl);
-  @include grid_gutter($ds-grid-gutter-xl);
+  @include grid_width(vac.$ds-grid-breakpoint-xl);
+  @include grid_gutter(vac.$ds-grid-gutter-xl);
   grid-template-areas:
   "breadcrumbs"
   "sidenav"
@@ -335,7 +336,7 @@ $fixed-anchor-width: 168px;
 
 
   @include auro_grid-breakpoint--md {
-    @include grid_padding($ds-grid-margin-md);
+    @include grid_padding(vac.$ds-grid-margin-md);
     grid-template-columns: var(--fixed-nav-width, $fixed-nav-width) auto var(--fixed-anchor-width, $fixed-anchor-width);
       grid-template-areas:
       "breadcrumbs breadcrumbs breadcrumbs"
@@ -343,16 +344,16 @@ $fixed-anchor-width: 168px;
   }
 
   @include auro_grid-breakpoint--lg {
-    @include grid_padding($ds-grid-margin-lg);
+    @include grid_padding(vac.$ds-grid-margin-lg);
   }
   @include auro_grid-breakpoint--xl {
-    @include grid_padding($ds-grid-margin-xl);
+    @include grid_padding(vac.$ds-grid-margin-xl);
   }
 
 
   .breadcrumbs {
     grid-area: breadcrumbs;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);
     }
@@ -362,7 +363,7 @@ $fixed-anchor-width: 168px;
     grid-area: sidenav;
     z-index: 1;
     background-color: var(--ds-color-container-primary-default, $ds-color-container-primary-default);
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include grid-stickycolumn--xs();
 
 
@@ -374,19 +375,19 @@ $fixed-anchor-width: 168px;
 
   .main {
     grid-area: main;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
     @include auro_grid-breakpoint--md {
     @include grid_padding(0);
     }
     * {
-      scroll-margin-top: var(--ds-grid-margin-md, $ds-grid-margin-md);
+      scroll-margin-top: var(--ds-grid-margin-md, vac.$ds-grid-margin-md);
     }
   }
 
   .anchornav {
     grid-area: anchornav;
     @include grid-stickycolumn--md;
-    @include grid_padding($ds-grid-margin-xs);
+    @include grid_padding(vac.$ds-grid-margin-xs);
 
     @include auro_grid-breakpoint--md {
       @include grid_padding(0);

--- a/tests/styleTest.scss
+++ b/tests/styleTest.scss
@@ -1,6 +1,7 @@
 // Import build resources to ensure that src resources are working as expected
 
 /* --------start variables import ------------- */
+@use '../node_modules/@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables' as vac;
 @import '../node_modules/@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables';
 /* --------end variables import ------------- */
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Migrate design token imports to Sass module `@use` with `vac` namespace and update all breakpoint, margin, padding, and gutter variable references accordingly. Update documentation to reflect version 8.1.0 and adjust tests to import `vac` variables. Disable related stylelint rules to support the new import syntax.

Enhancements:
- Refactor SCSS sources to use `@use '../node_modules/@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables' as vac` and prefix legacy design token variables with `vac.$...` in grids and breakpoints mixins
- Disable additional stylelint rules to allow the new `@use` syntax and import positioning

Documentation:
- Bump documentation version from 8.0.1 to 8.1.0 in the generated site

Tests:
- Add `@use ... as vac` import to the test stylesheet to validate updated SCSS variables