### PR TITLE
fix: adjust demo styles table selector to only ignore auro-table

### DIFF
--- a/src/elementDemoStyles/elementDemoStyles.scss
+++ b/src/elementDemoStyles/elementDemoStyles.scss
@@ -60,7 +60,7 @@ $paragraph: true;
     }
   }
 
-  main > table {
+  *:not(auro-table):not([auro-table]) table {
     @extend .auro_table;
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Related to
- AlaskaAirlines/auro-table#132

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Refine demo table selector from `main > table` to `*:not(auro-table):not([auro-table]) table` to prevent styling of auro-table elements